### PR TITLE
[#49] 플레이리스트 추가 페이지 상세 기능 구현

### DIFF
--- a/frontend/src/components/organisms/CreatePlaylistMusicList/index.tsx
+++ b/frontend/src/components/organisms/CreatePlaylistMusicList/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { MouseEventHandler, PropsWithChildren } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -9,6 +9,7 @@ import CreatePlaylistMusicItem from '../../molecules/CreatePlaylistMusicItem';
 
 interface Props {
   musics: Music[];
+  setIsOpenModal: MouseEventHandler;
 }
 
 const MusicListContainer = styled.div``;
@@ -61,7 +62,7 @@ const EmptyBox = styled.div`
   height: 100%;
   color: #ddd;
 `;
-const CreatePlaylistMusicList = ({ musics }: PropsWithChildren<Props>) => {
+const CreatePlaylistMusicList = ({ musics, setIsOpenModal }: PropsWithChildren<Props>) => {
   return (
     <MusicListContainer>
       <MusicListTitleBox>
@@ -73,6 +74,7 @@ const CreatePlaylistMusicList = ({ musics }: PropsWithChildren<Props>) => {
             fontSize={'12px'}
             paddingH={'7px'}
             width={'100px'}
+            onClick={setIsOpenModal}
           ></Button>
         </MusicListTitleTop>
         <MusicListTitleBottom>최소 3개, 최대 50개까지 추가가 가능합니다.</MusicListTitleBottom>
@@ -81,7 +83,7 @@ const CreatePlaylistMusicList = ({ musics }: PropsWithChildren<Props>) => {
         {!musics.length ? (
           <EmptyBox>노래를 추가해 주세요.</EmptyBox>
         ) : (
-          musics.map((music, idx) => <CreatePlaylistMusicItem title={music.title} key={idx} />)
+          musics.map((music, idx) => <CreatePlaylistMusicItem title={music.info} key={idx} />)
         )}
       </MusicListContentBox>
     </MusicListContainer>

--- a/frontend/src/components/organisms/CreatePlaylistMusicModal/index.tsx
+++ b/frontend/src/components/organisms/CreatePlaylistMusicModal/index.tsx
@@ -1,0 +1,155 @@
+import { PropsWithChildren, useCallback, useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import theme from '../../../styles/theme';
+import { Music } from '../../../types/music';
+import useEventListener from '../../../utils/useEventListener';
+import Button from '../../atoms/Button';
+import InputBox from '../../atoms/InputBox';
+import Chip from '../../molecules/Chip';
+import Modal from '../../molecules/Modal';
+
+interface Props {
+  setMusics: Function;
+  setIsOpenModal: Function;
+}
+
+const MusicModalTop = styled.div`
+  display: flex;
+  column-gap: 15px;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+const MusicModalTitle = styled.div`
+  font-size: 25px;
+  font-weight: bold;
+`;
+const MusicModalDescription = styled.div`
+  color: #999999;
+  font-size: 15px;
+`;
+const MusicModalInputBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  row-gap: 10px;
+  margin-bottom: 20px;
+`;
+const MusicModalChipContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 10px;
+  row-gap: 10px;
+  margin-bottom: 40px;
+`;
+
+const CreatePlaylistMusicModal = ({ setMusics, setIsOpenModal }: PropsWithChildren<Props>) => {
+  const [info, setInfo] = useState<string>('');
+  const [hint, setHint] = useState<string>('');
+  const [url, setUrl] = useState<string>('');
+  const [answer, setAnswer] = useState<string>();
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  const leftButtonHandler = useCallback(
+    (e) => {
+      setMusics((preState: Music[]) => [
+        ...preState,
+        {
+          info,
+          hint,
+          url,
+          answers,
+        },
+      ]);
+      setIsOpenModal(false);
+    },
+    [answers, hint, info, setIsOpenModal, setMusics, url],
+  );
+  const rightButtonHandler = useCallback(
+    (e) => {
+      setIsOpenModal(false);
+    },
+    [setIsOpenModal],
+  );
+
+  const pressEnterHandler = useCallback(
+    (e: globalThis.KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
+      if (!answer) return;
+      setAnswer('');
+      setAnswers((preState) => [...preState, answer]);
+    },
+    [answer],
+  );
+
+  useEventListener('keyup', pressEnterHandler);
+
+  return (
+    <Modal
+      height={'500px'}
+      maxWidth={'700px'}
+      leftButtonText={'등록'}
+      rightButtonText={'취소'}
+      leftButtonHanlder={leftButtonHandler}
+      rightButtonHanlder={rightButtonHandler}
+    >
+      <MusicModalTop>
+        <MusicModalTitle>노래 추가</MusicModalTitle>
+        <MusicModalDescription>(최소 3개, 최대 50개)</MusicModalDescription>
+        <Button
+          content={'초기화'}
+          background={theme.colors.sky}
+          height={'40px'}
+          width={'150px'}
+          paddingH={'10px'}
+        ></Button>
+      </MusicModalTop>
+      <MusicModalInputBox>
+        <InputBox
+          fontSize={'15px'}
+          height={'50px'}
+          isSearch={false}
+          placeholder={'노래 정보를 입력해 주세요. ex) 아이유 - 팔레트'}
+          width={'98%'}
+          value={info}
+          onChangeHandler={(e) => setInfo((e.currentTarget as HTMLTextAreaElement).value)}
+        ></InputBox>
+        <InputBox
+          fontSize={'15px'}
+          height={'50px'}
+          isSearch={false}
+          placeholder={'힌트를 입력해 주세요.'}
+          width={'98%'}
+          value={hint}
+          onChangeHandler={(e) => setHint((e.currentTarget as HTMLTextAreaElement).value)}
+        ></InputBox>
+        <InputBox
+          fontSize={'15px'}
+          height={'50px'}
+          isSearch={false}
+          placeholder={'유튜브 URL을 입력해 주세요.'}
+          width={'98%'}
+          value={url}
+          onChangeHandler={(e) => setUrl((e.currentTarget as HTMLTextAreaElement).value)}
+        ></InputBox>
+        <InputBox
+          fontSize={'15px'}
+          height={'50px'}
+          isSearch={false}
+          placeholder={'정답을 입력 후 Enter를 클릭해 주세요.'}
+          width={'98%'}
+          value={answer}
+          onChangeHandler={(e) => setAnswer((e.currentTarget as HTMLTextAreaElement).value)}
+        ></InputBox>
+      </MusicModalInputBox>
+      <MusicModalChipContainer>
+        {answers.map((answer, idx) => (
+          <Chip content={answer} key={idx} />
+        ))}
+      </MusicModalChipContainer>
+    </Modal>
+  );
+};
+
+export default CreatePlaylistMusicModal;

--- a/frontend/src/components/organisms/CreatePlaylistMusicModal/index.tsx
+++ b/frontend/src/components/organisms/CreatePlaylistMusicModal/index.tsx
@@ -53,6 +53,10 @@ const CreatePlaylistMusicModal = ({ setMusics, setIsOpenModal }: PropsWithChildr
 
   const leftButtonHandler = useCallback(
     (e) => {
+      if (!(info && hint && url && answers.length !== 0)) {
+        alert('노래 정보를 모두 입력해야합니다.');
+        return;
+      }
       setMusics((preState: Music[]) => [
         ...preState,
         {

--- a/frontend/src/pages/playlist/create/index.tsx
+++ b/frontend/src/pages/playlist/create/index.tsx
@@ -9,6 +9,7 @@ import PageBox from '../../../components/atoms/PageBox';
 import Chip from '../../../components/molecules/Chip';
 import CreatePlaylistInputBox from '../../../components/organisms/CreatePlaylistInputBox';
 import CreatePlaylistMusicList from '../../../components/organisms/CreatePlaylistMusicList';
+import CreatePlaylistMusicModal from '../../../components/organisms/CreatePlaylistMusicModal';
 import theme from '../../../styles/theme';
 import { Music } from '../../../types/music';
 import useEventListener from '../../../utils/useEventListener';
@@ -56,6 +57,7 @@ const PlaylistCreate: NextPage = () => {
   const [hashTag, setHashTag] = useState<string>('');
   const [chips, setChips] = useState<string[]>([]);
   const [musics, setMusics] = useState<Music[]>([]);
+  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
   const pressEnterHandler = useCallback(
     (e: globalThis.KeyboardEvent) => {
@@ -86,7 +88,10 @@ const PlaylistCreate: NextPage = () => {
               <Chip content={chip} key={idx}></Chip>
             ))}
           </ChipContainer>
-          <CreatePlaylistMusicList musics={musics}></CreatePlaylistMusicList>
+          <CreatePlaylistMusicList
+            musics={musics}
+            setIsOpenModal={(e) => setIsOpenModal(true)}
+          ></CreatePlaylistMusicList>
           <SubmitButtonWrapper>
             <Button
               content={'등록'}
@@ -98,6 +103,9 @@ const PlaylistCreate: NextPage = () => {
           </SubmitButtonWrapper>
         </Wrapper>
       </PageBox>
+      {isOpenModal && (
+        <CreatePlaylistMusicModal setIsOpenModal={setIsOpenModal} setMusics={setMusics}></CreatePlaylistMusicModal>
+      )}
     </Container>
   );
 };

--- a/frontend/src/types/music.d.ts
+++ b/frontend/src/types/music.d.ts
@@ -1,3 +1,6 @@
 export interface Music {
-  title: string;
+  info: string;
+  hint: string;
+  url: string;
+  answers: string[];
 }


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 노래 추가 버튼 클릭 시 노래 추가 모달 창 on
- 노래 추가 모달 창 구현
- 모달 창 내에서 노래 정보들을 입력할 수 있음.
- 모달 창에서 정답 입력 시 아래에 Chip 컴포넌트가 쌓이도록 구현
- 모달 창에서 등록 버튼 클릭 시 상위 컴포넌트의 isOpenModal 상태를 false로 바꾸어주고, setMusics 함수를 호출하여 음악을 등록함.
- 취소 버튼 클릭 시 음악은 등록되지 않고 모달 창만 off 됨.

<br/>

### 📘 작업 유형

- 신규 기능 추가

