### PR TITLE
[#3] 플레이리스트 내부 추가된 노래 삭제 기능 구현

### DIFF
--- a/frontend/src/components/atoms/InputBox/index.tsx
+++ b/frontend/src/components/atoms/InputBox/index.tsx
@@ -82,7 +82,7 @@ const InputBox = ({
         placeholder={placeholder}
         height={height}
         fontSize={fontSize}
-        value={value}
+        value={value || ''}
         onChange={onChangeHandler}
       ></TextInputContainer>
     </InputBoxContainer>

--- a/frontend/src/components/molecules/CreatePlaylistMusicItem/index.tsx
+++ b/frontend/src/components/molecules/CreatePlaylistMusicItem/index.tsx
@@ -7,6 +7,8 @@ import Button from '../../atoms/Button';
 
 interface Props {
   title: string;
+  deleteItem: Function;
+  idx: number;
 }
 
 const ItemContainer = styled.div`
@@ -26,13 +28,20 @@ const ButtonBox = styled.div`
   row-gap: 5px;
 `;
 
-const CreatePlaylistMusicItem = ({ title }: PropsWithChildren<Props>) => {
+const CreatePlaylistMusicItem = ({ title, deleteItem, idx }: PropsWithChildren<Props>) => {
   return (
     <ItemContainer>
       <MusicTitle>{title}</MusicTitle>
       <ButtonBox>
         <Button content={'수정'} background={theme.colors.sky} fontSize={'12px'} paddingH={'7px'} width={'100px'} />
-        <Button content={'삭제'} background={theme.colors.peach} fontSize={'12px'} paddingH={'7px'} width={'100px'} />
+        <Button
+          content={'삭제'}
+          background={theme.colors.peach}
+          fontSize={'12px'}
+          paddingH={'7px'}
+          width={'100px'}
+          onClick={(e) => deleteItem(idx)}
+        />
       </ButtonBox>
     </ItemContainer>
   );

--- a/frontend/src/components/organisms/CreatePlaylistMusicList/index.tsx
+++ b/frontend/src/components/organisms/CreatePlaylistMusicList/index.tsx
@@ -10,6 +10,7 @@ import CreatePlaylistMusicItem from '../../molecules/CreatePlaylistMusicItem';
 interface Props {
   musics: Music[];
   setIsOpenModal: MouseEventHandler;
+  setMusics: Function;
 }
 
 const MusicListContainer = styled.div``;
@@ -62,7 +63,7 @@ const EmptyBox = styled.div`
   height: 100%;
   color: #ddd;
 `;
-const CreatePlaylistMusicList = ({ musics, setIsOpenModal }: PropsWithChildren<Props>) => {
+const CreatePlaylistMusicList = ({ musics, setIsOpenModal, setMusics }: PropsWithChildren<Props>) => {
   return (
     <MusicListContainer>
       <MusicListTitleBox>
@@ -83,7 +84,9 @@ const CreatePlaylistMusicList = ({ musics, setIsOpenModal }: PropsWithChildren<P
         {!musics.length ? (
           <EmptyBox>노래를 추가해 주세요.</EmptyBox>
         ) : (
-          musics.map((music, idx) => <CreatePlaylistMusicItem title={music.info} key={idx} />)
+          musics.map((music, idx) => (
+            <CreatePlaylistMusicItem title={music.info} key={idx} idx={idx} deleteItem={setMusics} />
+          ))
         )}
       </MusicListContentBox>
     </MusicListContainer>

--- a/frontend/src/pages/playlist/create/index.tsx
+++ b/frontend/src/pages/playlist/create/index.tsx
@@ -91,6 +91,9 @@ const PlaylistCreate: NextPage = () => {
           <CreatePlaylistMusicList
             musics={musics}
             setIsOpenModal={(e) => setIsOpenModal(true)}
+            setMusics={(target: number) =>
+              setMusics((preState) => [...preState.filter((music, idx) => idx !== target)])
+            }
           ></CreatePlaylistMusicList>
           <SubmitButtonWrapper>
             <Button


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 플레이리스트 생성 페이지에서 추가된 노래 삭제 버튼 클릭 시 삭제되도록 구현
- 최상위 페이지의 상태인 musics의 index를 통해 노래를 식별하여 삭제시킴.

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>
