### PR TITLE
[#36] 스타일 확장을 이용한 태그 정리 및 개선

### DIFF
--- a/frontend/src/components/atoms/GlassContainer/index.tsx
+++ b/frontend/src/components/atoms/GlassContainer/index.tsx
@@ -1,16 +1,8 @@
-import { PropsWithChildren } from 'react';
-
 import styled from '@emotion/styled';
 
 import theme from '../../../styles/theme';
 
-// interface ContainerProps {
-//   type: '60%' | '80%';
-//   mode: '15%' | '60%';
-//   ratio: string;
-// }
-
-const Container = styled.div`
+const GlassContainer = styled.div`
   background-color: ${theme.colors.lightsky};
   display: flex;
   width: 100%;
@@ -20,10 +12,5 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
 `;
-
-// 1920 568 946
-const GlassContainer = ({ children }: any) => {
-  return <Container>{children}</Container>;
-};
 
 export default GlassContainer;

--- a/frontend/src/components/molecules/CharacterList/index.tsx
+++ b/frontend/src/components/molecules/CharacterList/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import theme from '../../../styles/theme';
 import CharacterProfile from '../CharacterProfile';
 
 const Title = styled.p`
@@ -10,7 +11,7 @@ const Container = styled.div`
   margin-right: auto;
   display: flex;
   flex-direction: column;
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+  @media (max-width: ${theme.breakpoints.sm}) {
     flex-direction: row;
     overflow: auto;
     justify-content: space-between;
@@ -22,7 +23,7 @@ interface props {
   status: 'king' | 'ready' | 'prepare';
 }
 
-const CharacterList = ({ children }: any) => {
+const CharacterList = () => {
   const dummy: props[] = [
     { color: 'ff', name: 'max', status: 'king' },
     { color: 'dwff', name: 'john', status: 'ready' },

--- a/frontend/src/components/molecules/CharacterList/index.tsx
+++ b/frontend/src/components/molecules/CharacterList/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import GlassContainer from '../../atoms/GlassContainer';
 import CharacterProfile from '../CharacterProfile';
 
 const Title = styled.p`
@@ -35,14 +34,14 @@ const CharacterList = ({ children }: any) => {
     { color: '234def', name: 'dd', status: 'ready' },
   ];
   return (
-    <GlassContainer>
+    <>
       <Title>사용자 목록</Title>
       <Container>
         {dummy.map((element, index) => (
           <CharacterProfile key={index} color={element.color} name={element.name} status={element.status} />
         ))}
       </Container>
-    </GlassContainer>
+    </>
   );
 };
 

--- a/frontend/src/components/molecules/ChatList/index.tsx
+++ b/frontend/src/components/molecules/ChatList/index.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import Chat from '../../atoms/Chat';
-import GlassContainer from '../../atoms/GlassContainer';
 const Container = styled.div`
   width: 100%;
   height: 100%;
@@ -47,13 +46,11 @@ const ChatList = () => {
   ];
 
   return (
-    <GlassContainer>
-      <Container>
-        {dummy.map((element, index) => (
-          <Chat key={index} name={element.name} text={element.text} status={element.status} />
-        ))}
-      </Container>
-    </GlassContainer>
+    <Container>
+      {dummy.map((element, index) => (
+        <Chat key={index} name={element.name} text={element.text} status={element.status} />
+      ))}
+    </Container>
   );
 };
 

--- a/frontend/src/components/organisms/GameRoomContainer/index.tsx
+++ b/frontend/src/components/organisms/GameRoomContainer/index.tsx
@@ -15,11 +15,11 @@ const Wrapper = styled.div`
   display: grid;
   gap: 10px;
   grid-template:
-    'leftTitle . rightTitle' 1fr
-    'leftCharacter . rightTitle' 1fr
-    'leftCharacter . rightChat' 6fr
-    'leftCharacter . rightSearch' 1fr
-    / 6fr 1fr 8fr;
+    '. leftTitle . rightTitle .' 1fr
+    '. leftCharacter . rightTitle .' 1fr
+    '. leftCharacter . rightChat .' 6fr
+    '. leftCharacter . rightSearch .' 1fr
+    /1fr 6fr 1fr 8fr 1fr;
   @media (max-width: ${theme.breakpoints.sm}) {
     grid-template:
       '.  leftCharacter leftCharacter leftCharacter .' 3fr

--- a/frontend/src/components/organisms/GameRoomContainer/index.tsx
+++ b/frontend/src/components/organisms/GameRoomContainer/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import theme from '../../../styles/theme';
 import GlassContainer from '../../atoms/GlassContainer';
 import CharacterList from '../../molecules/CharacterList';
 import ChatList from '../../molecules/ChatList';
@@ -18,8 +19,8 @@ const Wrapper = styled.div`
     'leftCharacter . rightTitle' 1fr
     'leftCharacter . rightChat' 6fr
     'leftCharacter . rightSearch' 1fr
-    / 4fr 1fr 6fr;
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    / 6fr 1fr 8fr;
+  @media (max-width: ${theme.breakpoints.sm}) {
     grid-template:
       '.  leftCharacter leftCharacter leftCharacter .' 3fr
       '. leftTitle rightTitle rightTitle .' 2fr

--- a/frontend/src/components/organisms/GameRoomContainer/index.tsx
+++ b/frontend/src/components/organisms/GameRoomContainer/index.tsx
@@ -5,7 +5,7 @@ import CharacterList from '../../molecules/CharacterList';
 import ChatList from '../../molecules/ChatList';
 
 interface Props {
-  type: 'leftTitle' | 'rightTitle';
+  type: 'leftTitle' | 'rightTitle' | 'leftCharacter' | 'rightChat';
 }
 
 const Wrapper = styled.div`
@@ -30,21 +30,14 @@ const Wrapper = styled.div`
   }
 `;
 
-const TitleContainer = styled.div<Props>`
+const Container = styled(GlassContainer)<Props>`
   grid-area: ${({ type }) => type};
-`;
-
-const ChatContainer = styled.div`
-  grid-area: rightChat;
 `;
 
 const RoomStateTitle = styled.p`
   font-weight: bolder;
 `;
 
-const CharacterContainer = styled.div`
-  grid-area: leftCharacter;
-`;
 const InputBox = styled.input`
   grid-area: rightSearch;
   border: 2px solid black;
@@ -60,20 +53,16 @@ const InputBox = styled.input`
 const GameRoomContainer = () => {
   return (
     <Wrapper>
-      <TitleContainer type={'leftTitle'}>
-        <GlassContainer>
-          <RoomStateTitle>대기중 입니다.</RoomStateTitle>
-        </GlassContainer>
-      </TitleContainer>
-      <CharacterContainer>
+      <Container type={'leftTitle'}>
+        <RoomStateTitle>대기중 입니다.</RoomStateTitle>
+      </Container>
+      <Container type={'leftCharacter'}>
         <CharacterList />
-      </CharacterContainer>
-      <TitleContainer type={'rightTitle'}>
-        <GlassContainer>대기중 입니다.</GlassContainer>
-      </TitleContainer>
-      <ChatContainer>
+      </Container>
+      <Container type={'rightTitle'}>대기중 입니다.</Container>
+      <Container type={'rightChat'}>
         <ChatList />
-      </ChatContainer>
+      </Container>
       <InputBox placeholder={'메세지를 입력해주세요.'} />
     </Wrapper>
   );

--- a/frontend/src/components/organisms/GameRoomNav/index.tsx
+++ b/frontend/src/components/organisms/GameRoomNav/index.tsx
@@ -13,7 +13,7 @@ const Container = styled.div`
     ' . . . .' 1fr
     / 1fr 4fr 1fr 1fr;
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+  @media (max-width: ${theme.breakpoints.sm}) {
     display: grid;
     grid-template:
       'speaker . start exit' 4fr
@@ -21,7 +21,7 @@ const Container = styled.div`
       / 1fr 4fr 1fr 1fr;
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+  @media (max-width: ${theme.breakpoints.sm}) {
     padding: 8px 2px;
     column-gap: 4px;
   }
@@ -30,7 +30,7 @@ const Container = styled.div`
 const ButtonWrapper = styled.div`
   width: 80%;
   height: 100%;
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+  @media (max-width: ${theme.breakpoints.sm}) {
     font-size: 10%;
   }
 `;
@@ -41,7 +41,7 @@ const MuteButton = styled.button`
   height: 60px;
   grid-area: speaker;
   background: url('images/ic_speaker.png') no-repeat center/45%;
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+  @media (max-width: ${theme.breakpoints.sm}) {
     width: 30px;
     height: 30px;
   }


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

-molecules의 characterList, ChatList 를 감싸고 있는 glassContainer 태그를 organisms에서 처리하도록 했습니다.

<br/>

### 📘 작업 유형

- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
<img width="416" alt="스크린샷 2021-11-07 오후 9 02 24" src="https://user-images.githubusercontent.com/38166372/140644056-28de784b-944c-40fa-9688-111bf0fa6968.png">

<img width="308" alt="스크린샷 2021-11-07 오후 9 02 17" src="https://user-images.githubusercontent.com/38166372/140644051-b3737be4-b1b1-4a6d-b71a-478a9b05056a.png">

기존의 glassContainer를 멘토님께서 말씀해주신 방법으로 스타일 만 선언하여, 스타일 확장으로 코드를 조금 더 간결하게 구현할 수 있었던 거 같습니다!
<br/><br/>
