### PR TITLE
[#86] 드래그 앤 드롭으로 노래 순서 변경 기능 구현

### DIFF
--- a/frontend/src/components/molecules/CreatePlaylistMusicItem/index.tsx
+++ b/frontend/src/components/molecules/CreatePlaylistMusicItem/index.tsx
@@ -1,15 +1,22 @@
-import { PropsWithChildren } from 'react';
+import { DragEventHandler, PropsWithChildren } from 'react';
 
 import styled from '@emotion/styled';
 
 import Button from '~/atoms/Button';
 import theme from '~/styles/theme';
 
+interface DragHandlers {
+  handleDragOver: DragEventHandler;
+  handleDragStart: DragEventHandler;
+  handleDrop: DragEventHandler;
+  handleDragEnd: DragEventHandler;
+}
 interface Props {
+  idx: number;
   title: string;
   deleteItem: Function;
   modifyItem: Function;
-  idx: number;
+  dragHandlers: DragHandlers;
 }
 
 const ItemContainer = styled.div`
@@ -18,6 +25,11 @@ const ItemContainer = styled.div`
   align-items: center;
   padding: 10px 5px 10px 5px;
   border-bottom: 2px solid #eee;
+  width: 100%;
+  cursor: grab;
+  :hover {
+    background-color: #eee;
+  }
 `;
 const MusicTitle = styled.p`
   font-size: 20px;
@@ -29,17 +41,25 @@ const ButtonBox = styled.div`
   row-gap: 5px;
 `;
 
-const CreatePlaylistMusicItem = ({ title, deleteItem, modifyItem, idx }: PropsWithChildren<Props>) => {
+const CreatePlaylistMusicItem = ({ idx, title, deleteItem, modifyItem, dragHandlers }: PropsWithChildren<Props>) => {
+  const { handleDragOver, handleDragStart, handleDrop, handleDragEnd } = dragHandlers;
   return (
-    <ItemContainer>
+    <ItemContainer
+      draggable
+      onDragOver={handleDragOver}
+      onDragStart={handleDragStart}
+      onDrop={handleDrop}
+      onDragEnd={handleDragEnd}
+      data-position={idx}
+    >
       <MusicTitle>{title}</MusicTitle>
       <ButtonBox>
         <Button
-          content={'수정'}
+          content="수정"
           background={theme.colors.sky}
-          fontSize={'12px'}
-          paddingH={'7px'}
-          width={'100px'}
+          fontSize="12px"
+          paddingH="7px"
+          width="100px"
           onClick={(e) => modifyItem()}
         />
         <Button

--- a/frontend/src/pages/playlist/create/index.tsx
+++ b/frontend/src/pages/playlist/create/index.tsx
@@ -129,9 +129,7 @@ const PlaylistCreate: NextPage = () => {
           <CreatePlaylistMusicList
             musics={musics}
             setModalOption={setModalOption}
-            setMusics={(target: number) =>
-              setMusics((preState) => [...preState.filter((music, idx) => idx !== target)])
-            }
+            setMusics={setMusics}
           ></CreatePlaylistMusicList>
           <SubmitButtonWrapper>
             <Button

--- a/frontend/src/utils/swap.ts
+++ b/frontend/src/utils/swap.ts
@@ -1,0 +1,6 @@
+export const swap = <T>(i: number, j: number, arr: T[]) => {
+  const temp = arr[i];
+  arr[i] = arr[j];
+  arr[j] = temp;
+  return arr;
+};


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 플레이리스트 생성 페이지에서 드래그 앤 드롭으로 노래 순서를 변경할 수 있는 기능을 구현함.

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>
