### PR TITLE
[#130] ffmpeg Input Stream 에러 해결, disconnect 이벤트 리스너가 단 한 번만 설정되도록 수정

### DIFF
--- a/backend/src/variables/YoutubeStream.ts
+++ b/backend/src/variables/YoutubeStream.ts
@@ -13,12 +13,11 @@ class Youtubestream {
     const MAX_LENGTH = 90;
     const regex = /(.*?)(^|\/|v=)([a-z0-9_-]{11})(.*)?/i;
     const videoId = (url.match(regex) as RegExpExecArray)[3];
-
-    const video = ytdl(`https://youtube.com/watch?v=${videoId}`, { quality: 'lowestaudio' });
     const stream = new PassThrough();
-    const ffmpeg = FFmpeg(video);
 
     process.nextTick(() => {
+      const video = ytdl(`https://youtube.com/watch?v=${videoId}`, { quality: 'lowestaudio' });
+      const ffmpeg = FFmpeg(video);
       const output = ffmpeg.noVideo().inputOptions(`-t ${MAX_LENGTH}`).format('mp3').pipe(stream);
 
       ffmpeg.once('error', (error: Error) => stream.emit('error', error));


### PR DESCRIPTION
## 📗 작업 내역
- ytdl로 video를 받아오는 부분을 process.nextTick 안에 넣음으로써 video가 없을 때 발생하는 Input Stream Error 해결
- disconnect 이벤트 리스너를 io.connect시 단 한 번만 설정되도록 수정