### PR TITLE
[#149] YoutubeStream에서 오디오를 미리 저장해두록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+backend/musics

--- a/backend/src/io.ts
+++ b/backend/src/io.ts
@@ -63,7 +63,6 @@ const getNextRound = (
     serverRooms[uuid].status = 'waiting';
     serverRooms[uuid].skipCount = 0;
     serverRooms[uuid].answerCount = 0;
-    serverRooms[uuid].streams.forEach((stream) => stream.destroy());
     serverRooms[uuid].streams = [];
     Object.keys(serverRooms[uuid].players).forEach((key) => {
       if (serverRooms[uuid].players[key].status !== 'king') {
@@ -90,7 +89,6 @@ const getNextRound = (
     }
 
     serverRooms[uuid].curRound += 1;
-    serverRooms[uuid].streams[0].destroy();
     serverRooms[uuid].streams.shift();
 
     if (curRound + 1 < musics.length) {
@@ -120,7 +118,6 @@ io.on('connection', (socket) => {
 
     if (!Object.keys(serverRooms[uuid].players).length) {
       if (serverRooms[uuid].timer) clearTimer(serverRooms[uuid].timer);
-      serverRooms[uuid].streams.forEach((stream) => stream.destroy());
       delete serverRooms[uuid];
       io.emit(SocketEvents.DELETE_LOBBY_ROOM, uuid);
       return;

--- a/backend/src/resources/game/controller.ts
+++ b/backend/src/resources/game/controller.ts
@@ -8,7 +8,6 @@ export const getInitialMusic = async (req: Request, res: Response) => {
     const { uuid } = req.params;
 
     if (!serverRooms[uuid]?.streams?.[0]?.stream) throw Error('stream을 찾을 수 없습니다');
-
     const stream = cloneable(serverRooms[uuid].streams[0].stream);
 
     for await (const chunk of stream) {
@@ -27,8 +26,7 @@ export const getNextMusic = async (req: Request, res: Response) => {
     const { uuid } = req.params;
 
     if (!serverRooms[uuid]?.streams?.[1]?.stream) throw Error('stream을 찾을 수 없습니다');
-
-    const stream = cloneable(serverRooms[uuid].streams[1].stream);
+    const stream = cloneable(serverRooms[uuid].streams[0].stream);
 
     for await (const chunk of stream) {
       res.write(chunk);


### PR DESCRIPTION
### 📗 코드 설명
- mp3 파일이 존재한다면, 읽어서 ReadStream으로 건네주도록 합니다.
- mp3 파일이 존재하지 않는다면, WriteStream으로 mp3를 저장하면서, PassThrough를 플레이어에게 건네줍니다.
- mp3 파일이 존재하지 않을 때, 이제는 mp3 파일을 무조건 다운로드 해놓아야 하므로, ffmpeg의 동작을 멈추기 위해 stream을 destroy할 필요가 없습니다.