### PR TITLE
[#149] stream에서 PassThrough와 관련된 버그 수정

### DIFF
--- a/backend/src/io.ts
+++ b/backend/src/io.ts
@@ -45,8 +45,16 @@ const setRoundTimer = (serverRoom: ServerRoom, uuid: string) => {
 
 const setWaitTimer = (serverRoom: ServerRoom, uuid: string, isExistNext: boolean) => {
   clearTimer(serverRoom.timer);
+
   serverRoom.timer = setTimeout(() => {
+    const { curRound, musics } = serverRoom;
+
     serverRoom.status = 'playing';
+
+    if (curRound < musics.length) {
+      serverRoom.streams.push(new Youtubestream(musics[curRound].url));
+    }
+
     io.to(uuid).emit(SocketEvents.SET_GAME_ROOM, getGameRoom(uuid));
     io.to(uuid).emit(SocketEvents.NEXT_ROUND, isExistNext);
     setHintTimer(serverRoom, uuid);
@@ -90,10 +98,6 @@ const getNextRound = (
 
     serverRooms[uuid].curRound += 1;
     serverRooms[uuid].streams.shift();
-
-    if (curRound + 1 < musics.length) {
-      serverRooms[uuid].streams.push(new Youtubestream(musics[curRound + 1].url));
-    }
 
     serverRooms[uuid].skipCount = 0;
     serverRooms[uuid].answerCount = 0;

--- a/backend/src/resources/game/controller.ts
+++ b/backend/src/resources/game/controller.ts
@@ -1,4 +1,3 @@
-import cloneable from 'cloneable-readable';
 import { Request, Response } from 'express';
 
 import serverRooms from '../../variables/serverRooms';
@@ -8,7 +7,7 @@ export const getInitialMusic = async (req: Request, res: Response) => {
     const { uuid } = req.params;
 
     if (!serverRooms[uuid]?.streams?.[0]?.stream) throw Error('stream을 찾을 수 없습니다');
-    const stream = cloneable(serverRooms[uuid].streams[0].stream);
+    const stream = serverRooms[uuid].streams[0].stream;
 
     for await (const chunk of stream) {
       res.write(chunk);
@@ -26,7 +25,7 @@ export const getNextMusic = async (req: Request, res: Response) => {
     const { uuid } = req.params;
 
     if (!serverRooms[uuid]?.streams?.[1]?.stream) throw Error('stream을 찾을 수 없습니다');
-    const stream = cloneable(serverRooms[uuid].streams[1].stream);
+    const stream = serverRooms[uuid].streams[1].stream;
 
     for await (const chunk of stream) {
       res.write(chunk);

--- a/backend/src/variables/YoutubeStream.ts
+++ b/backend/src/variables/YoutubeStream.ts
@@ -30,6 +30,10 @@ class Youtubestream {
     const video = ytdl(`https://youtube.com/watch?v=${videoId}`, { quality: 'lowestaudio' });
     const ffmpeg = FFmpeg(video);
 
+    ffmpeg.once('error', (error: Error) => {
+      passThrough.emit('error', error);
+    });
+
     process.nextTick(() => {
       ffmpeg.noVideo().inputOptions(`-t ${MAX_TIME_LENGTH}`).format('mp3').pipe(passThrough);
       passThrough.pipe(writeStream);

--- a/backend/src/variables/YoutubeStream.ts
+++ b/backend/src/variables/YoutubeStream.ts
@@ -1,7 +1,8 @@
-import fs, { ReadStream } from 'fs';
+import fs from 'fs';
 import { PassThrough } from 'stream';
 
 import { path } from '@ffmpeg-installer/ffmpeg';
+import cloneable from 'cloneable-readable';
 import FFmpeg from 'fluent-ffmpeg';
 import ytdl from 'ytdl-core';
 
@@ -38,7 +39,7 @@ class Youtubestream {
   }
 
   get stream() {
-    if (this.#passThrough) return this.#passThrough;
+    if (this.#passThrough) return cloneable(this.#passThrough);
     return fs.createReadStream(this.mp3Path);
   }
 }


### PR DESCRIPTION
### 📗 작업 내역
- stream이 PassThrough인 경우만 clone하도록 변경 (ReadStream인 경우 clone하지 않음)
- stream이 PassThrough인 경우 노래가 뒷부분부터 들리는 문제 해결
- ffmpeg error 핸들러 추가
