### PR TITLE
[#145, #149] YoutubeStream에서 ffmpeg를 사용하지 않도록 변경, 플레이리스트 추가 페이지 CSS 수정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,6 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@types/cookie-parser": "^1.4.2",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
@@ -40,7 +39,6 @@
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "fluent-ffmpeg": "^2.1.2",
     "got": "^11.8.2",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.0.12",

--- a/backend/src/variables/YoutubeStream.ts
+++ b/backend/src/variables/YoutubeStream.ts
@@ -1,12 +1,8 @@
 import fs from 'fs';
 import { PassThrough } from 'stream';
 
-import { path } from '@ffmpeg-installer/ffmpeg';
 import cloneable from 'cloneable-readable';
-import FFmpeg from 'fluent-ffmpeg';
 import ytdl from 'ytdl-core';
-
-FFmpeg.setFfmpegPath(path);
 
 class Youtubestream {
   videoId: string;
@@ -14,45 +10,46 @@ class Youtubestream {
   #passThrough?: PassThrough;
 
   constructor(url: string) {
-    this.videoId = this.parseUrl(url);
-    this.mp3Path = this.getMp3Path(this.videoId);
-    this.#passThrough = this.getPassThrough(this.videoId, this.mp3Path);
-  }
-
-  getPassThrough(videoId: string, mp3Path: string) {
-    if (!fs.existsSync(`musics`)) fs.mkdirSync('musics');
-    if (fs.existsSync(mp3Path) && fs.statSync(mp3Path).size > 0) return;
-
-    const MAX_TIME_LENGTH = 90;
-    const passThrough = new PassThrough();
-    const writeStream = fs.createWriteStream(mp3Path);
-    const video = ytdl(`https://youtube.com/watch?v=${videoId}`, { quality: 'lowestaudio' });
-    const ffmpeg = FFmpeg(video);
-
-    ffmpeg.once('error', (error: Error) => {
-      passThrough.emit('error', error);
-    });
-
-    process.nextTick(() => {
-      ffmpeg.noVideo().inputOptions(`-t ${MAX_TIME_LENGTH}`).format('mp3').pipe(passThrough);
-      passThrough.pipe(writeStream);
-    });
-
-    return passThrough;
-  }
-
-  getMp3Path(videoId: string) {
-    return `musics/${videoId}.mp3`;
-  }
-
-  parseUrl(url: string) {
-    const regex = /(.*?)(^|\/|v=)([a-z0-9_-]{11})(.*)?/i;
-    return (url.match(regex) as RegExpExecArray)[3];
+    this.videoId = this.#parseUrl(url);
+    this.mp3Path = this.#getMp3Path(this.videoId);
+    this.#passThrough = this.#getPassThrough(this.videoId, this.mp3Path);
   }
 
   get stream() {
     if (this.#passThrough) return cloneable(this.#passThrough);
     return fs.createReadStream(this.mp3Path);
+  }
+
+  #getPassThrough(videoId: string, mp3Path: string) {
+    const MAX_FILE_BYTE = 2 ** 20;
+    const NEED_FILE_BYTE = 2 ** 10;
+
+    if (!fs.existsSync(`musics`)) fs.mkdirSync('musics');
+    if (fs.existsSync(mp3Path) && fs.statSync(mp3Path).size > NEED_FILE_BYTE) return;
+
+    const passThrough = new PassThrough();
+    const writeStream = fs.createWriteStream(mp3Path);
+    const video = ytdl(`https://youtube.com/watch?v=${videoId}`, { quality: 'lowestaudio' });
+
+    video.pipe(passThrough);
+    passThrough.pipe(writeStream);
+
+    writeStream.on('drain', () => {
+      if (fs.statSync(mp3Path).size < MAX_FILE_BYTE) return;
+      video.pause();
+      writeStream.close();
+    });
+
+    return passThrough;
+  }
+
+  #getMp3Path(videoId: string) {
+    return `musics/${videoId}.mp3`;
+  }
+
+  #parseUrl(url: string) {
+    const regex = /(.*?)(^|\/|v=)([a-z0-9_-]{11})(.*)?/i;
+    return (url.match(regex) as RegExpExecArray)[3];
   }
 }
 

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -956,60 +956,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@ffmpeg-installer/darwin-arm64@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz#b7b5c262dd96d1aea4807514e1cdcf6e11f82743"
-  integrity sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==
-
-"@ffmpeg-installer/darwin-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz#48e1706c690e628148482bfb64acb67472089aaa"
-  integrity sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==
-
-"@ffmpeg-installer/ffmpeg@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz#87fdb9e7d180e8d78f7903f9441e36f978938a90"
-  integrity sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==
-  optionalDependencies:
-    "@ffmpeg-installer/darwin-arm64" "4.1.5"
-    "@ffmpeg-installer/darwin-x64" "4.1.0"
-    "@ffmpeg-installer/linux-arm" "4.1.3"
-    "@ffmpeg-installer/linux-arm64" "4.1.4"
-    "@ffmpeg-installer/linux-ia32" "4.1.0"
-    "@ffmpeg-installer/linux-x64" "4.1.0"
-    "@ffmpeg-installer/win32-ia32" "4.1.0"
-    "@ffmpeg-installer/win32-x64" "4.1.0"
-
-"@ffmpeg-installer/linux-arm64@4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz#7219f3f901bb67f7926cb060b56b6974a6cad29f"
-  integrity sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==
-
-"@ffmpeg-installer/linux-arm@4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz#c554f105ed5f10475ec25d7bec94926ce18db4c1"
-  integrity sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==
-
-"@ffmpeg-installer/linux-ia32@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz#adad70b0d0d9d8d813983d6e683c5a338a75e442"
-  integrity sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==
-
-"@ffmpeg-installer/linux-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz#b4a5d89c4e12e6d9306dbcdc573df716ec1c4323"
-  integrity sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==
-
-"@ffmpeg-installer/win32-ia32@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz#6eac4fb691b64c02e7a116c1e2d167f3e9b40638"
-  integrity sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==
-
-"@ffmpeg-installer/win32-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz#17e8699b5798d4c60e36e2d6326a8ebe5e95a2c5"
-  integrity sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==
-
 "@humanwhocodes/config-array@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
@@ -1516,11 +1462,6 @@ array.prototype.flat@^1.2.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.0"
-
-async@>=0.2.9:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
-  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -2527,14 +2468,6 @@ flatted@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
-
-fluent-ffmpeg@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz#c952de2240f812ebda0aa8006d7776ee2acf7d74"
-  integrity sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=
-  dependencies:
-    async ">=0.2.9"
-    which "^1.1.1"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4530,13 +4463,6 @@ which-boxed-primitive@^1.0.2:
     is-number-object "^1.0.4"
     is-string "^1.0.5"
     is-symbol "^1.0.3"
-
-which@^1.1.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
 
 which@^2.0.1:
   version "2.0.2"

--- a/frontend/src/components/atoms/PageBox/index.tsx
+++ b/frontend/src/components/atoms/PageBox/index.tsx
@@ -17,6 +17,7 @@ const BoxWrapper = styled.div`
 
 const BoxContainer = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: center;
   width: 100%;
   max-width: 1200px;

--- a/frontend/src/pages/playlist/[playlistId].tsx
+++ b/frontend/src/pages/playlist/[playlistId].tsx
@@ -32,6 +32,7 @@ const ChipContainer = styled.div`
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
   row-gap: 20px;
 `;
 const SubmitButtonWrapper = styled.div`


### PR DESCRIPTION
### 📗 작업 내역
- YoutubeStream에서 ffmpeg를 사용하지 않고 구글 비디오로부터 다운로드 받아오는 weba를 곧바로 사용하도록 변경
- 플레이리스트 추가 페이지 CSS 수정
