### PR TITLE
[#114] 게임 페이지 UI 개선

### DIFF
--- a/backend/src/sockets/events/game/sendChat.ts
+++ b/backend/src/sockets/events/game/sendChat.ts
@@ -22,11 +22,19 @@ function handleSendChat(this: Socket, uuid: string, name: string, text: string, 
     serverRooms[uuid].players[socket.id].answer = true;
     serverRooms[uuid].players[socket.id].score += Math.max(100 - serverRooms[uuid].answerCount * 20, 10);
     serverRooms[uuid].answerCount += 1;
-    io.to(uuid).emit(SocketEvents.RECEIVE_ANSWER, { uuid, name, text: '', status: 'answer' });
-    io.to(uuid).emit(SocketEvents.SET_GAME_ROOM, getGameRoom(uuid));
 
     const { answerCount, players, needAnswerRatio } = serverRooms[uuid];
-    if (answerCount >= Object.keys(players).length * needAnswerRatio) {
+    const needAnswerCount = Math.ceil(Object.keys(players).length * needAnswerRatio);
+
+    io.to(uuid).emit(SocketEvents.RECEIVE_ANSWER, {
+      uuid,
+      name,
+      text: `(정답 인원: ${answerCount}/${needAnswerCount} 명)`,
+      status: 'answer',
+    });
+    io.to(uuid).emit(SocketEvents.SET_GAME_ROOM, getGameRoom(uuid));
+
+    if (answerCount >= needAnswerCount) {
       getNextRound(uuid, { type: 'ANSWER', answerCount });
     }
   } catch (error) {

--- a/frontend/src/components/atoms/Chat/index.tsx
+++ b/frontend/src/components/atoms/Chat/index.tsx
@@ -39,7 +39,11 @@ const Chat = ({ name, text, status, color }: Props) => {
 
   if (status === 'alert') return <AlertMessage>{name + text}</AlertMessage>;
 
-  return <AlertMessage>{name}님께서 정답을 맞추셨습니다.</AlertMessage>;
+  return (
+    <AlertMessage>
+      {name}님께서 정답을 맞추셨습니다. {text}
+    </AlertMessage>
+  );
 };
 
 export default Chat;

--- a/frontend/src/pages/game/index.tsx
+++ b/frontend/src/pages/game/index.tsx
@@ -46,6 +46,7 @@ const Game: NextPage = () => {
   const router = useRouter();
   const dispatch = useDispatch();
 
+  const gameEndRoom = useRef(gameRoom);
   const music1 = useRef<HTMLAudioElement>(null);
   const music2 = useRef<HTMLAudioElement>(null);
   const curMusic: MutableRefObject<HTMLAudioElement | null> = useRef<HTMLAudioElement | null>(null);
@@ -137,12 +138,17 @@ const Game: NextPage = () => {
     gameRoom?.curRound,
   );
 
-  useSocketOn(SocketEvents.GAME_END, () => {
-    music1.current?.pause();
-    music2.current?.pause();
-    setDialogMsg(null);
-    setGameResultModalOnOff(true);
-  });
+  useSocketOn(
+    SocketEvents.GAME_END,
+    () => {
+      gameEndRoom.current = gameRoom;
+      music1.current?.pause();
+      music2.current?.pause();
+      setDialogMsg(null);
+      setGameResultModalOnOff(true);
+    },
+    gameRoom,
+  );
 
   useSocketOn(SocketEvents.SET_EXPULSION, (id: string) => {
     if (socket && id === socket.id) {
@@ -178,8 +184,8 @@ const Game: NextPage = () => {
       />
       {gameRoom && <GameRoomContainer gameRoom={gameRoom} endTime={timerEndTime} />}
       {dialogMsg && <BlurDialog title={dialogMsg.title} content={dialogMsg.content} />}
-      {gameResultModalOnOff && gameRoom && (
-        <GameResultModal gameRoom={gameRoom} userId={userInfo.id} setModalOnOff={setGameResultModalOnOff} />
+      {gameResultModalOnOff && gameEndRoom.current && (
+        <GameResultModal gameRoom={gameEndRoom.current} userId={userInfo.id} setModalOnOff={setGameResultModalOnOff} />
       )}
       <audio ref={music1} onEnded={handleAudioEnded} preload="none" />
       <audio ref={music2} onEnded={handleAudioEnded} preload="none" />


### PR DESCRIPTION
### 📗 작업 내역
- 게임 종료 당시의 gameRoom 데이터를 복사해 게임 결과 모달을 띄우도록 변경
- 정답을 맞췄을 때, 다음 라운드를 위한 필요 정답 인원 수를 보여주도록 변경